### PR TITLE
change scope option to a legitimate pinterest defined scope

### DIFF
--- a/lib/omniauth/strategies/pinterest.rb
+++ b/lib/omniauth/strategies/pinterest.rb
@@ -10,7 +10,7 @@ module OmniAuth
       }
 
       def request_phase
-        options[:scope] ||= 'read'
+        options[:scope] ||= 'read_public'
         options[:response_type] ||= 'code'
         super
       end


### PR DESCRIPTION
@jot @nlsrchtr would appreciate if one of you could merge this in. using the gem the way it is, omniauth authorization will not work because 'read' is not a defined scope for new pinterest api. See here: https://developers.pinterest.com/docs/api/overview/#scopes.

I just changed it to 'read_public' which is the equivalent of 'read'.