### PR TITLE
Add the ability to specify partial response fields for the /v1/me API request

### DIFF
--- a/lib/omniauth/strategies/pinterest.rb
+++ b/lib/omniauth/strategies/pinterest.rb
@@ -8,6 +8,7 @@ module OmniAuth
         :authorize_url => 'https://api.pinterest.com/oauth/',
         :token_url => 'https://api.pinterest.com/v1/oauth/token'
       }
+      option :fields, "id,first_name,last_name,url,username,account_type,bio,counts,image[small,medium,large],created_at"
 
       def request_phase
         options[:scope] ||= 'read_public'
@@ -20,7 +21,7 @@ module OmniAuth
       info { raw_info }
 
       def raw_info
-        @raw_info ||= access_token.get('/v1/me/').parsed['data']
+        @raw_info ||= access_token.get('/v1/me/', params: { fields: options[:fields] }).parsed['data']
       end
 
     end

--- a/lib/omniauth/strategies/pinterest.rb
+++ b/lib/omniauth/strategies/pinterest.rb
@@ -21,7 +21,7 @@ module OmniAuth
       info { raw_info }
 
       def raw_info
-        @raw_info ||= access_token.get('/v1/me/', params: { fields: options[:fields] }).parsed['data']
+        @raw_info ||= access_token.get('/v1/me/', params: { fields: options.fields }).parsed['data']
       end
 
     end


### PR DESCRIPTION
The Pinterest API supports "partial responses", and the /v1/me response only returns a subset of data. This provides a way to easily request the additional fields available.
