### PR TITLE
force SSL because Pinterest only allows SSL redirect URI's

### DIFF
--- a/lib/omniauth/strategies/pinterest.rb
+++ b/lib/omniauth/strategies/pinterest.rb
@@ -23,6 +23,10 @@ module OmniAuth
         @raw_info ||= access_token.get('/v1/me/').parsed['data']
       end
 
+      def ssl?
+        true
+      end
+
     end
   end
 end


### PR DESCRIPTION
Currently, and for the foreseeable future, Pinterest requires SSL for redirect URI's so this just sets that for the strategy all the time. Individual apps can still use non-SSL if they want, they'll just have to also support SSL for the auth url e.g. `https://example.com/users/auth/pinterest/callback`
