### PR TITLE
Modify info to return all available fields in Pinterest API endpoint

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,16 @@
 PATH
   remote: .
   specs:
-    omniauth-pinterest (1.0.1)
+    omniauth-pinterest (2.0.2)
       omniauth (~> 1.0)
       omniauth-oauth2 (~> 1.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.2.7)
-    crack (0.3.1)
+    addressable (2.4.0)
     diff-lcs (1.1.3)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.0.11)
     growl (1.0.3)
@@ -23,7 +22,7 @@ GEM
       guard (>= 0.2.2)
     guard-rspec (0.7.0)
       guard (>= 0.10.0)
-    hashie (3.4.2)
+    hashie (3.4.3)
     httpauth (0.2.1)
     jwt (0.1.6)
       multi_json (>= 1.0)
@@ -35,9 +34,9 @@ GEM
       jwt (~> 0.1.4)
       multi_json (~> 1.0)
       rack (~> 1.2)
-    omniauth (1.2.2)
+    omniauth (1.3.1)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     omniauth-oauth2 (1.1.1)
       oauth2 (~> 0.8.0)
       omniauth (~> 1.0)
@@ -58,9 +57,8 @@ GEM
       simplecov-html (~> 0.5.3)
     simplecov-html (0.5.3)
     thor (0.14.6)
-    webmock (1.8.6)
-      addressable (>= 2.2.7)
-      crack (>= 0.1.7)
+    webmock (0.9.1)
+      addressable (>= 2.1.1)
 
 PLATFORMS
   ruby
@@ -71,11 +69,11 @@ DEPENDENCIES
   guard-bundler
   guard-rspec
   omniauth-pinterest!
-  rack-test
+  rack-test (~> 0)
   rb-fsevent
   rspec (~> 2.7)
-  simplecov
-  webmock
+  simplecov (~> 0)
+  webmock (~> 0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/lib/omniauth-pinterest/version.rb
+++ b/lib/omniauth-pinterest/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Pinterest
-    VERSION = '2.0.1'
+    VERSION = '2.0.2'
   end
 end

--- a/lib/omniauth/strategies/pinterest.rb
+++ b/lib/omniauth/strategies/pinterest.rb
@@ -20,9 +20,9 @@ module OmniAuth
       info { raw_info }
 
       def raw_info
-        @raw_info ||= access_token.get('/v1/me/').parsed['data']
+        fields = 'first_name,id,last_name,url,account_type,username,bio,image'
+        @raw_info ||= access_token.get("/v1/me/?fields=#{fields}").parsed['data']
       end
-
     end
   end
 end


### PR DESCRIPTION
The Pinterest API by default does not return all the relevant fields that could be stored inside the info hash. My team needs some of those fields for our integration and we thought others could benefit from having these fields available as well. I've simply modified the request URI to include all the fields that someone would want from Pinterest.
